### PR TITLE
182 Running Branta again when app is hidden results in two instances

### DIFF
--- a/Branta/MainWindow.xaml.cs
+++ b/Branta/MainWindow.xaml.cs
@@ -58,13 +58,6 @@ public partial class MainWindow
             SetLanguageDictionary(languageStore);
             Analytics.Init(appSettings);
             SetResizeImage(ImageScreenSize);
-
-            var args = Environment.GetCommandLineArgs();
-
-            if (args.Contains("headless"))
-            {
-                OnClosing(new CancelEventArgs());
-            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Fixes the following
 1. Running Branta again when app is hidden results in two instances
 2. Running on Startup should run in "headless" mode where app does not appear, but can be opened from the app drawer

Closes #182 